### PR TITLE
fix: index zero padding correction

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -123,7 +123,7 @@ a decision created on ./docs/adr/0000-use-adr-tool.md
     .replace(/# /g, '')
 
     const newIndex = getLatestIndex()
-    const fileIndex = ('000000' + newIndex).slice(3)
+    const fileIndex = ('000000' + newIndex).slice(-4)
     const filename = fileIndex + '-' + cleanTitle
 
     let fileData = raw


### PR DESCRIPTION
Need to adjust this `.slice` to count from the end of the string, rather than the beginning, to properly left-pad the index with zeroes.